### PR TITLE
feat: bump dependents when dependency is bumped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+packages/*/.npmrc

--- a/packages/monorepo-release/.npmrc
+++ b/packages/monorepo-release/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/packages/monorepo-release/package.json
+++ b/packages/monorepo-release/package.json
@@ -19,6 +19,7 @@
 		"release": "node dist/index.js"
 	},
 	"dependencies": {
+		"@changesets/get-dependents-graph": "^1.3.6",
 		"@commitlint/parse": "17.7.0",
 		"@manypkg/get-packages": "^2.2.0",
 		"git-log-parser": "1.2.0",

--- a/packages/monorepo-release/src/analyze.ts
+++ b/packages/monorepo-release/src/analyze.ts
@@ -17,6 +17,7 @@ export async function analyze(config: Config): Promise<PackageToRelease[]> {
 	const packageList = packages.packages.filter((p) => !p.packageJson.private)
 	const dependentsGraph = await getDependentsGraph({
 		...packages,
+		packages: packageList,
 		// @ts-expect-error See: https://github.com/Thinkmill/manypkg/blob/main/packages/get-packages/CHANGELOG.md#200
 		root: packages.rootPackage,
 	})

--- a/packages/monorepo-release/src/analyze.ts
+++ b/packages/monorepo-release/src/analyze.ts
@@ -14,7 +14,7 @@ export async function analyze(config: Config): Promise<PackageToRelease[]> {
 		config
 
 	const packages = await getPackages(process.cwd())
-	const packageList = packages.packages
+	const packageList = packages.packages.filter((p) => !p.packageJson.private)
 	const dependentsGraph = await getDependentsGraph({
 		...packages,
 		// @ts-expect-error See: https://github.com/Thinkmill/manypkg/blob/main/packages/get-packages/CHANGELOG.md#200

--- a/packages/monorepo-release/src/index.ts
+++ b/packages/monorepo-release/src/index.ts
@@ -1,27 +1,32 @@
 import { defaultConfig } from "./config.js"
 import { shouldSkip } from "./skip.js"
-import { verify as verify } from "./verify.js"
 import { analyze } from "./analyze.js"
 import { publish } from "./publish.js"
 import { log } from "./utils.js"
+import { bold, green } from "yoctocolors"
 
 const userConfig = {} // TODO: Allow user config
+const config = { ...defaultConfig, ...userConfig }
 
-const config = { ...defaultConfig, userConfig }
 if (config.dryRun) {
-	console.log("\nPerforming dry run, no packages will be published!\n")
+	log.info(bold(green("Performing dry run, no packages will be released!\n")))
+} else {
+	log.info(bold(green("Let's release some packages!\n")))
 }
+
+log.debug("Configuration:", JSON.stringify(config, null, 2))
 
 if (shouldSkip({ releaseBranches: config.releaseBranches })) {
 	process.exit(0)
 }
 
 if (config.dryRun) {
-	console.log("\nDry run, skip validation...\n")
+	log.debug("Dry run, skipping token validation...\n")
 } else if (config.noVerify) {
-	console.log("\n--no-verify or NO_VERIFY set, skipping token validation...\n")
+	log.info("--no-verify or NO_VERIFY set, skipping token validation...\n")
 } else {
-	await verify()
+	if (!process.env.NPM_TOKEN) throw new Error("NPM_TOKEN is not set")
+	if (!process.env.GITHUB_TOKEN) throw new Error("GITHUB_TOKEN is not set")
 }
 
 const packages = await analyze(defaultConfig)

--- a/packages/monorepo-release/src/publish.ts
+++ b/packages/monorepo-release/src/publish.ts
@@ -26,9 +26,7 @@ export async function publish(packages: PackageToRelease[], options: Config) {
 	for await (const pkg of packages) {
 		if (dryRun) {
 			log.info(
-				`Dry run, \`${bold(
-					pkg.name + "@" + pkg.newVersion,
-				)}\` won't be released`,
+				`Dry run won't release \`${bold(pkg.name + "@" + pkg.newVersion)}\``,
 			)
 		} else {
 			log.info(
@@ -41,10 +39,9 @@ export async function publish(packages: PackageToRelease[], options: Config) {
 		}
 
 		let npmPublish = `pnpm publish --access public --registry=https://registry.npmjs.org --no-git-checks`
-		// We use different tokens for `next-auth` and `@next-auth/*` packages
-
 		if (dryRun) {
-			npmPublish += " --dry-run --silent"
+			npmPublish += " --dry-run"
+			if (!options.verbose) npmPublish += " --silent"
 		} else {
 			execSync(
 				"echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc",

--- a/packages/monorepo-release/src/types.ts
+++ b/packages/monorepo-release/src/types.ts
@@ -52,4 +52,5 @@ export interface GrouppedCommits {
 	bugfixes: Commit[]
 	other: Commit[]
 	breaking: Commit[]
+	dependents: string[]
 }

--- a/packages/monorepo-release/src/utils.ts
+++ b/packages/monorepo-release/src/utils.ts
@@ -47,3 +47,16 @@ export const log = {
 export function execSync(...args: Parameters<typeof nodeExecSync>) {
 	return nodeExecSync(args[0], { stdio: "inherit", ...args[1] })
 }
+
+export function pluralize(word: string, count: number) {
+	const pluralRules = new Intl.PluralRules("en", { type: "cardinal" })
+	const pluralForm = pluralRules.select(count)
+	switch (pluralForm) {
+		case "one":
+			return word
+		case "other":
+			return word + "s" // simple pluralization, may need adjustment based on the word
+		default:
+			return word
+	}
+}

--- a/packages/monorepo-release/src/verify.ts
+++ b/packages/monorepo-release/src/verify.ts
@@ -1,8 +1,0 @@
-export async function verify() {
-	if (!process.env.NPM_TOKEN) {
-		throw new Error("NPM_TOKEN is not set")
-	}
-	if (!process.env.GITHUB_TOKEN) {
-		throw new Error("GITHUB_TOKEN is not set")
-	}
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   packages/monorepo-release:
     dependencies:
+      '@changesets/get-dependents-graph':
+        specifier: ^1.3.6
+        version: 1.3.6
       '@commitlint/parse':
         specifier: 17.7.0
         version: 17.7.0
@@ -45,6 +48,12 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
 
+  packages/test:
+    dependencies:
+      '@balazsorban/monorepo-release':
+        specifier: workspace:*
+        version: link:../monorepo-release
+
 packages:
 
   /@babel/code-frame@7.22.13:
@@ -69,6 +78,31 @@ packages:
       js-tokens: 4.0.0
     dev: false
 
+  /@babel/runtime@7.23.1:
+    resolution: {integrity: sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.0
+    dev: false
+
+  /@changesets/get-dependents-graph@1.3.6:
+    resolution: {integrity: sha512-Q/sLgBANmkvUm09GgRsAvEtY3p1/5OCzgBE5vX3vgb5CvW0j7CEljocx5oPXeQSNph6FXulJlXV3Re/v3K3P3Q==}
+    dependencies:
+      '@changesets/types': 5.2.1
+      '@manypkg/get-packages': 1.1.3
+      chalk: 2.4.2
+      fs-extra: 7.0.1
+      semver: 7.5.4
+    dev: false
+
+  /@changesets/types@4.1.0:
+    resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
+    dev: false
+
+  /@changesets/types@5.2.1:
+    resolution: {integrity: sha512-myLfHbVOqaq9UtUKqR/nZA/OY7xFjQMdfgfqeZIBK4d0hA6pgxArvdv8M+6NUzzBsjWLOtvApv8YHr4qM+Kpfg==}
+    dev: false
+
   /@commitlint/parse@17.7.0:
     resolution: {integrity: sha512-dIvFNUMCUHqq5Abv80mIEjLVfw8QNuA4DS7OWip4pcK/3h5wggmjVnlwGCDvDChkw2TjK1K6O+tAEV78oxjxag==}
     engines: {node: '>=v14'}
@@ -85,6 +119,15 @@ packages:
       chalk: 4.1.2
     dev: false
 
+  /@manypkg/find-root@1.1.0:
+    resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
+    dependencies:
+      '@babel/runtime': 7.23.1
+      '@types/node': 12.20.55
+      find-up: 4.1.0
+      fs-extra: 8.1.0
+    dev: false
+
   /@manypkg/find-root@2.2.1:
     resolution: {integrity: sha512-34NlypD5mmTY65cFAK7QPgY5Tzt0qXR4ZRXdg97xAlkiLuwXUPBEXy5Hsqzd+7S2acsLxUz6Cs50rlDZQr4xUA==}
     engines: {node: '>=14.18.0'}
@@ -92,6 +135,17 @@ packages:
       '@manypkg/tools': 1.1.0
       find-up: 4.1.0
       fs-extra: 8.1.0
+    dev: false
+
+  /@manypkg/get-packages@1.1.3:
+    resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+    dependencies:
+      '@babel/runtime': 7.23.1
+      '@changesets/types': 4.1.0
+      '@manypkg/find-root': 1.1.0
+      fs-extra: 8.1.0
+      globby: 11.1.0
+      read-yaml-file: 1.1.0
     dev: false
 
   /@manypkg/get-packages@2.2.0:
@@ -135,6 +189,10 @@ packages:
 
   /@types/minimist@1.2.3:
     resolution: {integrity: sha512-ZYFzrvyWUNhaPomn80dsMNgMeXxNWZBdkuG/hWlUvXvbdUH8ZERNBGXnU87McuGcWDsyzX2aChCv/SVN348k3A==}
+    dev: false
+
+  /@types/node@12.20.55:
+    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: false
 
   /@types/node@20.8.0:
@@ -367,6 +425,15 @@ packages:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
+    dev: false
+
+  /fs-extra@7.0.1:
+    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
+    engines: {node: '>=6 <7 || >=8'}
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
     dev: false
 
   /fs-extra@8.1.0:
@@ -766,6 +833,10 @@ packages:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+    dev: false
+
+  /regenerator-runtime@0.14.0:
+    resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
     dev: false
 
   /resolve@1.22.6:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,12 +48,6 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
 
-  packages/test:
-    dependencies:
-      '@balazsorban/monorepo-release':
-        specifier: workspace:*
-        version: link:../monorepo-release
-
 packages:
 
   /@babel/code-frame@7.22.13:


### PR DESCRIPTION
Whenever a package that has dependencies in the workspace is released, all the dependent packages should be bumped too automatically.

This PR will track dependents of a package being released, and bumps them too.

It works as follows:

1. If only the dependency changes, bump, add all dependency comments under "Other" with the scope `dependency`. Release as a patch
2. If the dependent itself introduced changes, do the same as 1, but the version will be determined by the version that is higher of the dependency or the dependent
3. If two packages being released have no correlation, nothing happens