### PR TITLE
fix: add newline at the end of package.json after update

### DIFF
--- a/packages/monorepo-release/src/utils.ts
+++ b/packages/monorepo-release/src/utils.ts
@@ -24,8 +24,7 @@ async function update(
   const content = JSON.stringify({ ...original, ...data }, null, 2)
   await fs.writeFile(
     path.join(process.cwd(), directory, "package.json"),
-    content,
-    "utf8",
+    `${content}\n`,
   )
 }
 

--- a/packages/monorepo-release/src/utils.ts
+++ b/packages/monorepo-release/src/utils.ts
@@ -8,23 +8,25 @@ import { Config, defaultConfig } from "./config.js"
 
 async function read(
   directory: string,
-): Promise<Required<PackageJson & { release?: Partial<Config> }>> {
+  raw?: boolean
+): Promise<Required<PackageJson & { release?: Partial<Config> }> | string> {
   const content = await fs.readFile(
     path.join(process.cwd(), directory, "package.json"),
     "utf8",
   )
-  return JSON.parse(content)
+  return raw ? content : JSON.parse(content)
 }
 
 async function update(
   directory: string,
   data: Partial<PackageJson>,
 ): Promise<void> {
-  const original = await pkgJson.read(directory)
-  const content = JSON.stringify({ ...original, ...data }, null, 2)
+  const original = await pkgJson.read(directory, true) as string
+  let content = JSON.stringify({ ...JSON.parse(original), ...data }, null, 2)
+  content += original.endsWith("\r\n") ? "\r\n" : "\n"
   await fs.writeFile(
     path.join(process.cwd(), directory, "package.json"),
-    `${content}\n`,
+    content,
   )
 }
 
@@ -68,8 +70,8 @@ export function pluralize(
     typeof count === "number"
       ? count
       : count instanceof Set || count instanceof Map
-      ? count.size
-      : count.length
+        ? count.size
+        : count.length
 
   const pluralForm = pluralRules.select(count)
   switch (pluralForm) {


### PR DESCRIPTION
This was the previous unaltered output from `fs.writeFile()`. Notice the last missing `$`, `$` being the symbol for new-line (`\n`) in the `cat -e` output.

![image](https://github.com/balazsorban44/monorepo-release/assets/7415984/1b1fe4da-33ad-413b-aa24-3f44fc70d33b)


- Add missing `\n` to the end of the stringified `package.json` to be written in `update()`
- Remove `utf-8` third argument as its the default